### PR TITLE
Remove 404ing fontawesome version-only sass import

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -11,8 +11,6 @@
 @import url({{ $fontsUrl }})
 {{ end }}
 
-@import url({{ $fontAwesomeVersion }})
-
 {{ with $fontAwesomeVersion }}
 {{ $fontAwesomeUrl := printf "https://use.fontawesome.com/releases/v%s/css/all.css" . }}
 @import url({{ $fontAwesomeUrl }})


### PR DESCRIPTION
Page rendering blocks on a request to `theupdateframework.io/css/5.12.0` until it 404s (takes +6s on my box).

This PR removes the corresponding sass url import, as it seems irrelevant (the corresponding resource does not exist and the desired font stylesheet is actually loaded in the subsequent line).
